### PR TITLE
fix for python 3.7 and 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 - Updated MLflow exporter to work with the current neptune.ai API ([#40](https://github.com/neptune-ai/neptune-mlflow/pull/40))
 
 ### Fixes
-- Fix to support Python 3.7 and 3.8 ()
+- Fix to support Python 3.7 and 3.8 ([#43](https://github.com/neptune-ai/neptune-mlflow/pull/43))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 
 ### Changes
 - Updated MLflow exporter to work with the current neptune.ai API ([#40](https://github.com/neptune-ai/neptune-mlflow/pull/40))
+
+### Fixes
+- Fix to support Python 3.7 and 3.8 ()

--- a/src/neptune_mlflow_exporter/impl/components/fetcher.py
+++ b/src/neptune_mlflow_exporter/impl/components/fetcher.py
@@ -16,7 +16,7 @@
 
 __all__ = ["Fetcher"]
 
-from collections.abc import MutableMapping
+from typing import MutableMapping
 from dataclasses import dataclass
 from typing import (
     List,


### PR DESCRIPTION
Exporter currently fails with Py 3.7 and 3.8.

Ref: https://github.com/neptune-ai/examples/actions/runs/5356218988/jobs/9715474787?pr=250#step:5:525

Solution: https://stackoverflow.com/questions/59955751/abcmeta-object-is-not-subscriptable-when-trying-to-annotate-a-hash-variable

Tested locally